### PR TITLE
Support ESLint customization in the template package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,11 +210,17 @@ createApp(projectName, npx)
         templatePackageJson.scripts
       );
 
+      // As the default ESLint configuration is fully captured in the sharable
+      // eslint-config-react-app package, we don't expect any changes in the
+      // app package.json. So, we allow any customizations in the template to
+      // take precendence.
+      const eslintConfig = templatePackageJson.eslintConfig || appPackageJson.eslintConfig;
+
       const packageJson = Object.assign(
         {},
         templatePackageJson,
         appPackageJson,
-        { scripts }
+        { scripts, eslintConfig }
       );
 
       fs.writeFileSync(


### PR DESCRIPTION
Hi @fcaldera, hope this finds you well! It's been a while, but I'm still using craft, and I'm back with a few more changes motivated by the CRA 3.3.0 release. I already pushed a couple of small commits to master that update the dependencies and resolve an outstanding TODO (motivated by the addition of 3 dependencies in the default CRA template).

But I had another idea that I thought would be useful, and I wanted to give you an opportunity to weigh in first...

My idea is that it would be good to allow craft templates to customize the ESLint configuration in `package.json`. Even previously, when react-scripts would ignore such customizations, it was helpful to provide a more strict configuration that would be used by your editor and by the `eslint` CLI directly. But now they explicitly support [extending the ESLint configuration](https://create-react-app.dev/docs/setting-up-your-editor/#experimental-extending-the-eslint-config), so I think it's a great time to add this in craft.

They already build the whole configuration into a eslint-config-react-app package, so I would expect any future changes would go there, and the default configuration that's generated in `package.json` will never change from what it is today:

```
  "eslintConfig": {
    "extends": "react-app"
  },
```

So, it seems safe to just replace that by whatever appears in the `package.json` in the craft template. That's what I'm doing in this PR, and I'm just falling back to the app configuration from CRA if there is no `eslintConfig` section in the craft template.

What do you think? Does this seem like a good idea to you?